### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -3,4 +3,4 @@ spring:
     name: locks
   cloud:
     config:
-      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:http://user:password@localhost:8888}
+      uri: ${vcap.services.${PREFIX:}configserver.credentials.uri:https://user:password@localhost:8888}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://user:password@localhost:8888 (UnknownHostException) with 1 occurrences migrated to:  
  https://user:password@localhost:8888 ([https](https://user:password@localhost:8888) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences